### PR TITLE
Surface command failures to HomeKit instead of swallowing them

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -92,6 +92,13 @@
             "required": true,
             "default": 5,
             "description": "Max number of times to retry API calls"
+          },
+          "connection_timeout": {
+            "title": "Connection Timeout",
+            "type": "number",
+            "required": false,
+            "default": 30000,
+            "description": "HTTP connection timeout in milliseconds. Default is 30 seconds (30000)."
           }
         }
       }
@@ -145,7 +152,8 @@
       "expanded": false,
       "items": [
         "advanced_settings.polling_interval",
-        "advanced_settings.max_api_retries"
+        "advanced_settings.max_api_retries",
+        "advanced_settings.connection_timeout"
       ]
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-sky-lite-evolve",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-sky-lite-evolve",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -3,7 +3,7 @@ import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, 
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
 import { EvolveProjectorAccessory } from './projectorAccessory';
 
-import { getDeviceInfo } from './tuyaCloudApi';
+import { getDeviceInfo, isTimeoutError, isConnectionRefusedError } from './tuyaCloudApi';
 
 
 /**
@@ -30,10 +30,11 @@ export class EvolvePlatform implements DynamicPlatformPlugin {
     // Dynamic Platform plugins should only register new accessories after this event was fired,
     // in order to ensure they weren't added to homebridge already. This event can also be used
     // to start discovery of new accessories.
-    this.api.on('didFinishLaunching', async () => {
+    this.api.on('didFinishLaunching', () => {
       this.log.debug('Executed didFinishLaunching callback');
-      // run the method to discover / register your devices as accessories
-      this.discoverDevices();
+      this.discoverDevices().catch((error) => {
+        this.log.error('Unhandled error during device discovery:', error);
+      });
     });
   }
 
@@ -65,7 +66,19 @@ export class EvolvePlatform implements DynamicPlatformPlugin {
   async discoverDevices() {
     // loop over the discovered devices and register each one
     for (const projector of this.config.projectors) {
-      const response = await getDeviceInfo(projector.tuya_device_id, this.config, this.log);
+      let response;
+      try {
+        response = await getDeviceInfo(projector.tuya_device_id, this.config, this.log);
+      } catch (error) {
+        if (isTimeoutError(error)) {
+          this.log.error(`Failed to discover projector ${projector.tuya_device_id}: connection timed out`);
+        } else if (isConnectionRefusedError(error)) {
+          this.log.error(`Failed to discover projector ${projector.tuya_device_id}: connection refused`);
+        } else {
+          this.log.error(`Failed to discover projector ${projector.tuya_device_id}:`, error);
+        }
+        continue;
+      }
       this.log.debug('Discovered projector:', response);
       this.devices.push({
         UniqueId: response.result.uuid,

--- a/src/projectorAccessory.ts
+++ b/src/projectorAccessory.ts
@@ -2,7 +2,7 @@ import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 
 import { EvolvePlatform } from './platform';
 
-import { getDeviceInfo, getDeviceStatus, postDeviceCommands } from './tuyaCloudApi';
+import { getDeviceInfo, getDeviceStatus, postDeviceCommands, isTimeoutError, isConnectionRefusedError } from './tuyaCloudApi';
 
 
 interface CloudState {
@@ -73,14 +73,19 @@ export class EvolveProjectorAccessory {
   private async getDeviceDetails() {
     this.platform.log.debug('Fetching device details for <Device ID: ', this.accessory.context.device.TuyaDeviceId);
     try {
-      const device = getDeviceInfo(this.accessory.context.device.TuyaDeviceId, this.platform.config, this.platform.log);
+      const device = await getDeviceInfo(this.accessory.context.device.TuyaDeviceId, this.platform.config, this.platform.log);
       this.platform.log.debug('Device Details: ', device);
       this.cloud_state.initialized = true;
       this.platform.log.debug('Device initialized!');
       return device;
-      this.platform.log.debug('Initial cloud state: ', JSON.stringify(this.cloud_state));
     } catch (error) {
-      this.platform.log.error('Failed to initialize device:', error);
+      if (isTimeoutError(error)) {
+        this.platform.log.error('Failed to initialize device: connection timed out');
+      } else if (isConnectionRefusedError(error)) {
+        this.platform.log.error('Failed to initialize device: connection refused');
+      } else {
+        this.platform.log.error('Failed to initialize device:', error);
+      }
     }
   }
 
@@ -104,14 +109,25 @@ export class EvolveProjectorAccessory {
    * @returns A promise that resolves when the value is successfully set.
    */
   async setOn(value: CharacteristicValue) {
-    // implement your own code to turn your device on/off
     this.platform.log.debug('Set Characteristic On ->', value);
     if (!this.cloud_state.initialized) {
       this.platform.log.debug('Device is not initialized yet. Cannot set new status.');
-    } else if (!this.cloud_state.populated) {
+      throw new this.platform.api.hap.HapStatusError(
+        this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+    if (!this.cloud_state.populated) {
       this.platform.log.debug('State is not populated yet. Cannot set new status.');
-    } else {
-      await this.updateCloudState('switch_led', value as boolean);
+      throw new this.platform.api.hap.HapStatusError(
+        this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+    const ok = await this.updateCloudState('switch_led', value as boolean);
+    if (!ok) {
+      // Snap HomeKit back to the actual cloud-reported state so the UI doesn't
+      // claim the toggle succeeded.
+      this.powerSwitchService?.updateCharacteristic(
+        this.platform.Characteristic.On, this.cloud_state.switch_led as boolean);
+      throw new this.platform.api.hap.HapStatusError(
+        this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
     }
   }
 
@@ -170,7 +186,17 @@ export class EvolveProjectorAccessory {
       this.platform.log.debug('Device is not initialized yet. Cannot refresh status.');
     } else {
       this.platform.log.debug(`Refreshing status of <Device ID: ${this.device.result.id}> from Tuya cloud...`);
-      await getDeviceStatus(this.accessory.context.device.TuyaDeviceId, this.platform.config, this.platform.log).then(async (response) => {
+      await getDeviceStatus(this.accessory.context.device.TuyaDeviceId, this.platform.config, this.platform.log).catch((error) => {
+        if (isTimeoutError(error)) {
+          this.platform.log.error('refreshCloudState failed: connection timed out');
+        } else if (isConnectionRefusedError(error)) {
+          this.platform.log.error('refreshCloudState failed: connection refused');
+        } else {
+          throw error;
+        }
+        throw new this.platform.api.hap.HapStatusError(
+          this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }).then(async (response) => {
         this.platform.log.debug('Tuya response (response): ', JSON.stringify(response));
         let resultObject: { [key: string]: string } = {};
 
@@ -203,34 +229,48 @@ export class EvolveProjectorAccessory {
    * They're declared above in the interface
    * @returns {Promise<void>} - A promise that resolves when the cloud state is successfully updated.
    */
-  async updateCloudState(code: string, new_value: boolean | string | number): Promise<void> {
+  async updateCloudState(code: string, new_value: boolean | string | number): Promise<boolean> {
     this.platform.log.debug('Pushing new state to Tuya cloud...');
-    await postDeviceCommands(
-      this.accessory.context.device.TuyaDeviceId,
-      this.platform.config,
-      this.platform.log,
-      code,
-      new_value,
-    ).then(async (response) => {
+    try {
+      const response = await postDeviceCommands(
+        this.accessory.context.device.TuyaDeviceId,
+        this.platform.config,
+        this.platform.log,
+        code,
+        new_value,
+      );
       this.platform.log.debug('Response successful: ', String(response.success));
-      if (response.result === true) {
-        // this.platform.log.debug('Successfully pushed new state to Tuya cloud!');
-        this.platform.log.debug('Polling to validate new remote state...');
-        for (let i = 0; i < this.platform.config.advanced_settings.max_api_retries; i++) {
-          this.platform.log.debug('Attempt #' + String(i + 1));
-          await this.refreshCloudState();
-          if (this.cloud_state[code] === new_value) {
-            this.platform.log.debug('New state successfully polled!');
-            return;
-          }
-          // Wait for a short period of time before the next attempt
-          await new Promise(resolve => setTimeout(resolve, this.platform.config.advanced_settings.polling_interval));
-        }
-        this.platform.log.error('Failed to update after ' + this.platform.config.advanced_settings.max_api_retries + ' attempts');
-      } else {
+      if (!response.result) {
         this.platform.log.error('Failed to push new state to Tuya cloud!');
+        return false;
       }
-    });
+      this.platform.log.debug('Polling to validate new remote state...');
+      for (let i = 0; i < this.platform.config.advanced_settings.max_api_retries; i++) {
+        this.platform.log.debug('Attempt #' + String(i + 1));
+        await this.refreshCloudState();
+        if (this.cloud_state[code] === new_value) {
+          this.platform.log.debug('New state successfully polled!');
+          return true;
+        }
+        await new Promise(resolve => setTimeout(resolve, this.platform.config.advanced_settings.polling_interval));
+      }
+      this.platform.log.error(
+        `Device did not reach ${code}=${String(new_value)} after ` +
+        `${this.platform.config.advanced_settings.max_api_retries} polls`);
+      return false;
+    } catch (error) {
+      if (isTimeoutError(error)) {
+        this.platform.log.error('updateCloudState failed: connection timed out');
+        throw new this.platform.api.hap.HapStatusError(
+          this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      } else if (isConnectionRefusedError(error)) {
+        this.platform.log.error('updateCloudState failed: connection refused');
+        throw new this.platform.api.hap.HapStatusError(
+          this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      this.platform.log.error('updateCloudState failed:', error);
+      return false;
+    }
   }
 }
 

--- a/src/tuyaCloudApi.ts
+++ b/src/tuyaCloudApi.ts
@@ -5,6 +5,23 @@ import * as qs from 'qs';
 import axios from 'axios';
 import * as crypto from 'crypto';
 
+const DEFAULT_TIMEOUT_MS = 30000;
+
+function createHttpClient(config: PlatformConfig) {
+  return axios.create({
+    baseURL: config.cloud_credentials.tuya_region,
+    timeout: config.advanced_settings?.connection_timeout ?? DEFAULT_TIMEOUT_MS,
+  });
+}
+
+export function isTimeoutError(err: unknown): boolean {
+  return axios.isAxiosError(err) && (err.code === 'ECONNABORTED' || err.code === 'ERR_CANCELED');
+}
+
+export function isConnectionRefusedError(err: unknown): boolean {
+  return axios.isAxiosError(err) && err.code === 'ECONNREFUSED';
+}
+
 
 export async function getTuyaToken(config: PlatformConfig, logger: Logger): Promise<string> {
   const method = 'GET';
@@ -21,9 +38,7 @@ export async function getTuyaToken(config: PlatformConfig, logger: Logger): Prom
     sign: await encryptStr(signStr, config.cloud_credentials.tuya_secret_key),
   };
 
-  const httpClient = axios.create({
-    baseURL: config.cloud_credentials.tuya_region,
-  });
+  const httpClient = createHttpClient(config);
 
   const { data: login } = await httpClient.get('/v1.0/token?grant_type=1', { headers });
   logger.debug(JSON.stringify(headers));
@@ -41,9 +56,7 @@ export async function getDeviceInfo(deviceId: string, config: PlatformConfig, lo
   const url = `/v1.0/devices/${deviceId}`;
   const reqHeaders: { [k: string]: string } = await getRequestSign(url, method, {}, query, {}, config, token);
 
-  const httpClient = axios.create({
-    baseURL: config.cloud_credentials.tuya_region,
-  });
+  const httpClient = createHttpClient(config);
 
   const { data } = await httpClient.request({
     method,
@@ -66,9 +79,7 @@ export async function getDeviceStatus(deviceId: string, config: PlatformConfig, 
   const url = `/v1.0/devices/${deviceId}/status`;
   const reqHeaders: { [k: string]: string } = await getRequestSign(url, method, {}, query, {}, config, token);
 
-  const httpClient = axios.create({
-    baseURL: config.cloud_credentials.tuya_region,
-  });
+  const httpClient = createHttpClient(config);
 
   const { data } = await httpClient.request({
     method,
@@ -105,9 +116,7 @@ export async function postDeviceCommands(
   } ;
   const reqHeaders: { [k: string]: string } = await getRequestSign(url, method, {}, query, body, config, token);
 
-  const httpClient = axios.create({
-    baseURL: config.cloud_credentials.tuya_region,
-  });
+  const httpClient = createHttpClient(config);
 
   const { data } = await httpClient.request({
     method,


### PR DESCRIPTION
Fixes #6 .

setOn now throws SERVICE_COMMUNICATION_FAILURE when the device fails to reach the requested state, and reverts the On characteristic to the last cloud-reported value so the Home app reflects reality. Also fix a missing await in getDeviceDetails that masked init failures.